### PR TITLE
Replace pkg_resources with importlib_metadata to speed up Janis (hopefully)

### DIFF
--- a/janis/data_types/__init__.py
+++ b/janis/data_types/__init__.py
@@ -1,9 +1,9 @@
-import sys
 from janis_core.utils.logger import Logger
-import pkg_resources
+from janis_core.registry.entrypoints import DATATYPES
+import importlib_metadata
 
-
-for entrypoint in pkg_resources.iter_entry_points(group="janis.types"):
+eps = importlib_metadata.entry_points().get(DATATYPES, [])
+for entrypoint in eps:
     try:
         m = entrypoint.load()
         for k, v in m.__dict__.items():

--- a/janis/tools/__init__.py
+++ b/janis/tools/__init__.py
@@ -1,9 +1,10 @@
-import sys
+import importlib_metadata
 from janis_core.utils.logger import Logger
-import pkg_resources
+from janis_core.registry.entrypoints import TOOLS
 
+eps = importlib_metadata.entry_points().get(TOOLS, [])
 
-for entrypoint in pkg_resources.iter_entry_points(group="janis.tools"):
+for entrypoint in eps:
     try:
         m = entrypoint.load()
         for k, v in m.__dict__.items():


### PR DESCRIPTION
As title suggestions, see PMCC-BioinformaticsCore/janis-core/pull/4