### PR TITLE
Remove an extra comma

### DIFF
--- a/docs/tutorials/tutorial2.md
+++ b/docs/tutorials/tutorial2.md
@@ -96,7 +96,7 @@ SamtoolsFlagstat = CommandToolBuilder(
     version="1.9.0",
     
     inputs=[],  # List[ToolInput]
-    outputs=[], # List[ToolOutput]
+    outputs=[] # List[ToolOutput]
 )
 ```
 


### PR DESCRIPTION
Remove an extra comma from some python code, so it cut-and-pastes correctly.