### PR TITLE
Fix formatting of text

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -83,6 +83,7 @@ Inputs and Outputs
 We'll split the inputs / outputs in two ways:
 
 1. Step based:
+
     - The inputs to a *step* is the data that specific tool needs to process.
     - The outputs to a *step* is what the *tool* produces.
 


### PR DESCRIPTION
Was reading the docs today while testing some WDL workflow, when I noticed a formatting that appeared to be incorrect.

I think the `1. Step based:` is highlighted due to the missing newline (copied from another section further ahead where the formatting was correct).

![image](https://user-images.githubusercontent.com/304786/139192520-1bcec901-dd9e-4033-84d6-041749213a33.png)

Bruno