### PR TITLE
Release v0.13.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup, find_packages
 # Version information is found in the __init__ file of `janis/`
 DESCRIPTION = "Contains classes and helpers to build a workflow, and provide options to convert to CWL / WDL"
 
-JANIS_CORE_VERSION = "v0.13.0"
+JANIS_CORE_VERSION = "v0.13.1"
 JANIS_ASSISTANT_VERSION = "v0.13.0"
 JANIS_UNIX_VERSION = "v0.12.0"
 JANIS_BIOINFORMATICS_VERSION = "v0.12.2"
-JANIS_PIPELINES_VERSION = "v0.12.0"
+JANIS_PIPELINES_VERSION = "v0.13.0"
 JANIS_TEMPLATES_VERSION = "v0.12.0"
 
 ######## SHOULDN'T NEED EDITS BELOW THIS LINE ########


### PR DESCRIPTION
Updated dependency to janis-core and janis-pipelines versions for bug fixes of the following:

- WDL output translations from the CLI is now working again
- Updated nextflow translation from Janis to fix edge cases
- Updated galaxy ingest